### PR TITLE
Pass environment variables to the puppet Command

### DIFF
--- a/lib/beaker/testmode_switcher/beaker_runners.rb
+++ b/lib/beaker/testmode_switcher/beaker_runners.rb
@@ -41,12 +41,15 @@ module Beaker
           end
         end
 
-        on(default, # rubocop:disable Style/MultilineMethodCallBraceLayout
-           puppet(*cmd),
-           dry_run: opts[:dry_run],
-           environment: opts[:environment] || {},
-           acceptable_exit_codes: (0...256)
-          )
+        # Environment variables must be passed directly to puppet()
+        cmd << { 'ENV' => (opts[:environment] || {}) }
+        on(
+          default,
+          puppet(*cmd),
+          dry_run: opts[:dry_run],
+          environment: opts[:environment] || {},
+          acceptable_exit_codes: (0...256)
+        )
       end
 
       # copy a file using beaker's scp_to to all hosts
@@ -82,12 +85,15 @@ module Beaker
 
         # acceptable_exit_codes are passed because we want detailed-exit-codes but want to
         # make our own assertions about the responses
-        on(default, # rubocop:disable Style/MultilineMethodCallBraceLayout
-           puppet(*cmd),
-           dry_run: opts[:dry_run],
-           environment: opts[:environment] || {},
-           acceptable_exit_codes: (0...256)
-          )
+        # Environment variables must be passed directly to puppet()
+        cmd << { 'ENV' => (opts[:environment] || {}) }
+        on(
+          default,
+          puppet(*cmd),
+          dry_run: opts[:dry_run],
+          environment: opts[:environment] || {},
+          acceptable_exit_codes: (0...256)
+        )
       end
     end
 


### PR DESCRIPTION
Beaker::Command objects can be built with environment variables, and if
`on()` is passed a Beaker::Command then it ignores the environment
variables passed to `on()` . IMHO this is a beaker bug, though the
resolution of which may take a while so I'm going to leave the old way
AND add the new way.
