### PR TITLE
Implement catch_changes, catch_failures, expect_changes and expect_failures in beaker_runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ This experimental version supports only a minimal set of functionality from the 
   * `:values`: pass a hash of key/value pairs which is passed on the commandline to `puppet resource` to influence the specified resource.
   * `:dry_run`: set to true to skip executing the actual command.
   * `:environment`: pass environment variables for the command as a hash.
+  * `:catch_failures` enables detailed exit codes and causes a test failure if the puppet run indicates there was a failure during its execution.
+  * `:catch_changes` enables detailed exit codes and causes a test failure if the puppet run indicates that there were changes or failures during its execution.
+  * `:expect_changes` enables detailed exit codes and causes a test failure if the puppet run indicates that there were no resource changes during its execution.
+  * `:expect_failures` enables detailed exit codes and causes a test failure if the puppet run indicates there were no failure during its execution.
 
 * `scp_to_ex(from, to)`: Copies the file `from` to the location `to` on all nodes.
 

--- a/lib/beaker/testmode_switcher/local_runner.rb
+++ b/lib/beaker/testmode_switcher/local_runner.rb
@@ -1,10 +1,11 @@
 require 'shellwords'
 require 'open3'
+require_relative 'runner_base'
 
 module Beaker
   module TestmodeSwitcher
     # All functionality specific to running in 'local' mode
-    class LocalRunner
+    class LocalRunner < RunnerBase
       # creates the file on the local machine and adjusts permissions
       # the opts hash allows the following keys: :mode, :user, :group
       def create_remote_file_ex(file_path, file_content, opts = {})
@@ -31,7 +32,11 @@ module Beaker
         cmd << "--debug" if opts[:debug]
         cmd << "--noop" if opts[:noop]
         cmd << "--trace" if opts[:trace]
-        use_local_shell(cmd.join(' '), opts)
+
+        res = use_local_shell(cmd.join(' '), opts)
+        handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), res.exit_code)
+
+        res
       end
 
       # build and execute complex puppet resource commands locally

--- a/lib/beaker/testmode_switcher/runner_base.rb
+++ b/lib/beaker/testmode_switcher/runner_base.rb
@@ -1,0 +1,35 @@
+module Beaker
+  module TestmodeSwitcher
+    # A standard error to be raised by runner classes when an unexpected exit code is returned
+    class UnacceptableExitCodeError < RuntimeError
+    end
+
+    # Contains functions used in both local runner and beaker runners
+    class RunnerBase
+      def get_acceptable_puppet_run_exit_codes(opts = {})
+        # Ensure only one option given
+        if [opts[:catch_changes], opts[:catch_failures], opts[:expect_failures], opts[:expect_changes]].compact.length > 1
+          raise(ArgumentError,
+                'Cannot specify more than one of `catch_failures`, \
+                 `catch_changes`, `expect_failures`, or `expect_changes` \
+                  for a single manifest')
+        end
+
+        # Return appropriate exit code
+        return [0]        if opts[:catch_changes]
+        return [0, 2]     if opts[:catch_failures]
+        return [1, 4, 6]  if opts[:expect_failures]
+        return [2]        if opts[:expect_changes]
+
+        # If no option supplied, return all exit codes, as an array,
+        # as acceptable so beaker returns a detailed output
+        (0...256)
+      end
+
+      def handle_puppet_run_returned_exit_code(acceptable_exit_codes, returned_exit_code)
+        return if acceptable_exit_codes.include?(returned_exit_code)
+        raise UnacceptableExitCodeError, "Unacceptable exit code returned: #{returned_exit_code}. Acceptable code(s): #{acceptable_exit_codes.join(', ')}"
+      end
+    end
+  end
+end

--- a/spec/beaker/testmode_switcher/runner_base_spec.rb
+++ b/spec/beaker/testmode_switcher/runner_base_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Beaker::TestmodeSwitcher::RunnerBase do
+  subject { Beaker::TestmodeSwitcher::RunnerBase.new }
+
+  context 'get_acceptable_puppet_run_exit_codes' do
+    context ':catch_changes option passed' do
+      it 'exit code of 0 given' do
+        expect(subject.get_acceptable_puppet_run_exit_codes(catch_changes: true)).to eq([0])
+      end
+    end
+
+    context ':catch_changes option passed' do
+      it 'exit codes of 0 & 2 given' do
+        expect(subject.get_acceptable_puppet_run_exit_codes(catch_failures: true)).to eq([0, 2])
+      end
+    end
+
+    context ':catch_changes option passed' do
+      it 'exit codes 1, 4 & 6 given' do
+        expect(subject.get_acceptable_puppet_run_exit_codes(expect_failures: true)).to eq([1, 4, 6])
+      end
+    end
+
+    context ':catch_changes option passed' do
+      it 'exit code of 2 given' do
+        expect(subject.get_acceptable_puppet_run_exit_codes(expect_changes: true)).to eq([2])
+      end
+    end
+
+    context 'no options passed' do
+      it 'exit codes 0 - 256 given' do
+        expect(subject.get_acceptable_puppet_run_exit_codes).to eq((0...256))
+      end
+    end
+  end
+
+  context 'handle_puppet_run_returned_exit_code' do
+    it 'throws UnacceptableExitCodeError when unacceptable exit code given' do
+      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 5) }.to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError, /Unacceptable exit code returned/i)
+    end
+
+    it 'not throw UnacceptableExitCodeError when acceptable exit code given' do
+      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 2) }.to_not raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError)
+    end
+  end
+end


### PR DESCRIPTION


I added these options to the beaker runners to make implementation of test tiering into an existing module easier. These changes allowed me to do a find/replace on apply_manifest -> execute_manifest for the NTP module and with very little other changes, have the tests run successfully.