### PR TITLE
[WIP] Changing scp to rsync for multinode

### DIFF
--- a/lib/beaker/testmode_switcher/beaker_runners.rb
+++ b/lib/beaker/testmode_switcher/beaker_runners.rb
@@ -49,10 +49,10 @@ module Beaker
           )
       end
 
-      # copy a file using beaker's scp_to to all hosts
+      # copy a file using beaker's rsync_to to all hosts
       def scp_to_ex(from, to)
         @hosts.each do |host|
-          scp_to host, from, to
+          rsync_to host, from, to
         end
       end
 


### PR DESCRIPTION
This is working in progress. When BEAKER_TESTMODE=agent testmode switcher will rsync files from master to the agent rather than scp. Once it is proved out that this will work, I plan on making more changes. There is a local scp_to_ex therefore I haven't changed the function name until I see how this will affect actually running it. I then plan on changing/extending tests.