### PR TITLE
(FM-5893) - Adding multinode functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,20 @@ Style/FrozenStringLiteralComment:
 
 Style/SafeNavigation:
   Enabled: false
+
+# Disabling unrealistic rubocop RSpec cops
+RSpec/HookArgument:
+   Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+# We want to call gem files multiple times if they have a ruby version dependency
+Bundler/DuplicatedGem:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,19 +3,19 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rubocop', require: false
+  gem 'beaker' if RUBY_VERSION > '2.1.6'
+  gem 'beaker', '2.42.0' if RUBY_VERSION <= '2.1.6'
   gem 'bundler', '~> 1.9'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3' unless ENV['TEST_FRAMEWORK'] && ENV['TEST_FRAMEWORK'] == 'beaker' # Don't install rpsec if the module is in beaker only mode
-  gem 'beaker', '2.42.0' if RUBY_VERSION <= '2.1.6'
-  gem 'beaker' if RUBY_VERSION > '2.1.6'
+  gem 'rubocop', require: false
 end
 
 group :development do
-  gem 'pry'
   gem 'guard'
   gem 'guard-rake'
   gem 'guard-rspec' unless ENV['TEST_FRAMEWORK'] && ENV['TEST_FRAMEWORK'] == 'beaker'
-  gem 'pry-coolline'
   gem 'listen', '= 3.0.7' # last version to support ruby 1.9; the proper fix would be to not install the development group in our internal CI
+  gem 'pry'
+  gem 'pry-coolline'
 end

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This experimental version supports only a minimal set of functionality from the 
 
 * `create_remote_file_ex(file_path, file_content, opts = {})`: Creates a file at `file_path` with the content specified in `file_content` on the default node. `opts` can have the keys `:mode`, `:user`, and `:group` to specify the permissions, owner, and group respectively.
 
-* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. Depending on the `BEAKER_TESTMODE` environment variable, this may use `puppet agent` or `puppet apply`.
+* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. This will only work when `BEAKER_TESTMODE`, is set to `agent` and it will run a `puppet agent` run.
   `opts` keys:
   * `:debug`, `:trace`, `:noop`: set to true to enable the puppet option of the same name.
   * `:dry_run`: set to true to skip executing the actual command.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ This experimental version supports only a minimal set of functionality from the 
 
 * `create_remote_file_ex(file_path, file_content, opts = {})`: Creates a file at `file_path` with the content specified in `file_content` on the default node. `opts` can have the keys `:mode`, `:user`, and `:group` to specify the permissions, owner, and group respectively.
 
-* `execute_manifest(manifest, opts = {})`: Execute the manifest on the default node. Depending on the `BEAKER_TESTMODE` environment variable, this may use `puppet agent` or `puppet apply`.
+* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. Depending on the `BEAKER_TESTMODE` environment variable, this may use `puppet agent` or `puppet apply`.
   `opts` keys:
   * `:debug`, `:trace`, `:noop`: set to true to enable the puppet option of the same name.
   * `:dry_run`: set to true to skip executing the actual command.
   * `:environment`: pass environment variables for the command as a hash.
+
+* `execute_manifest(manifest, opts = {})`: Execute the manifest on the default node. Depending on the `BEAKER_TESTMODE` environment variable, this may use `puppet agent` or `puppet apply`.
+  `opts` This makes use of `execute_manifest_on(hosts, manifest, opts = {})`.
 
 * `resource(type, name, opts = {})`: Runs `puppet resource` with the specified `type` and `name` arguments.
   `opts` keys:

--- a/lib/beaker/testmode_switcher/beaker_runners.rb
+++ b/lib/beaker/testmode_switcher/beaker_runners.rb
@@ -70,6 +70,12 @@ module Beaker
       # upload the manifest to the master and inject it into the site.pp
       # then run a puppet agent on the default host
       def execute_manifest(manifest, opts = {})
+        execute_manifest_on(default, manifest, opts)
+      end
+
+      # upload the manifest to the master and inject it into the site.pp
+      # then run a puppet agent on all hosts
+      def execute_manifest_on(hosts, manifest, opts = {})
         environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
         prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
         site_pp = create_site_pp(master, manifest: manifest)
@@ -82,12 +88,11 @@ module Beaker
 
         # acceptable_exit_codes are passed because we want detailed-exit-codes but want to
         # make our own assertions about the responses
-        on(default,
+        on(hosts,
            puppet(*cmd),
            dry_run: opts[:dry_run],
            environment: opts[:environment] || {},
-           acceptable_exit_codes: (0...256)
-          )
+           acceptable_exit_codes: (0...256))
       end
     end
 

--- a/lib/beaker/testmode_switcher/dsl.rb
+++ b/lib/beaker/testmode_switcher/dsl.rb
@@ -5,7 +5,7 @@ module Beaker
     # include this module into your namespace to access the DSL parts of TestmodeSwitcher
     module DSL
       # pass through methods to the runner
-      [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest].each do |name|
+      [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest, :execute_manifest_on].each do |name|
         define_method(name) do |*args|
           Beaker::TestmodeSwitcher.runner(hosts, logger).send(name, *args)
         end

--- a/spec/beaker/testmode_switcher/dsl_spec.rb
+++ b/spec/beaker/testmode_switcher/dsl_spec.rb
@@ -38,6 +38,13 @@ describe Beaker::TestmodeSwitcher::DSL do
     end
   end
 
+  describe '#execute_manifest_on' do
+    it 'is callable' do
+      is_expected.to receive(:execute_manifest_on)
+      execute_manifest_on(hosts, 'manifest', {})
+    end
+  end
+
   describe '#runner' do
     it_behaves_like "a runner"
   end

--- a/spec/support/examples/a_runner.rb
+++ b/spec/support/examples/a_runner.rb
@@ -1,5 +1,5 @@
 shared_examples 'a runner' do
-  [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest].each do |name|
+  [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest, :execute_manifest_on].each do |name|
     it { is_expected.to respond_to(name) }
   end
 end


### PR DESCRIPTION
This is adding multinode functionality. A new function has been created that allows a puppet run on all of the nodes rather than limiting it to only one node. Tests have also been extended for this function.

It is now possible to run:
execute_manifest_on(hosts, manifest, opts={}) to apply the manifest on all nodes. 

It is still possible to run on the default node by using:
execute_manifest(manifest, opts={})

I created sample tests in NTP to run to ensure it is possible to actually use this function and the existing function. 
The following is an example of a test I ran:

  it 'applies cleanly on' do
    execute_manifest_on(hosts, pp, :catch_failures => true) do |r|
      expect(r.stderr).not_to match(/error/i)
    end
  end

  it 'applies cleanly' do
    execute_manifest(pp, :catch_failures => true) do |r|
      expect(r.stderr).not_to match(/error/i)
    end
  end

I can confirm that when calling execute_manifest the manifest is only applied to the default node and when I run execute_manifest_on the manifest is applied to all of the nodes in the nodeset.