### PR TITLE
Release prep v0.1.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,7 @@ RSpec/DescribedClass:
 # We want to call gem files multiple times if they have a ruby version dependency
 Bundler/DuplicatedGem:
   Enabled: false
+
+# When there are dependencies we have duplicate gems so they cant be ordered
+Bundler/OrderedGems:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
 # Version 0.1.0
 
 Initial release.
+
+# 2017-01-19 - Version 0.1.1
+###Summary
+
+This release adds a feature that provides control of specific nodes you would like to run an agent run on. Previously it was only possible to run on the default node.
+
+###Features
+- Add execute_manifest_on() function
+- Add MAINTAINERS file
+- Addressing Rubocop errors

--- a/beaker-testmode_switcher.gemspec
+++ b/beaker-testmode_switcher.gemspec
@@ -6,7 +6,7 @@ require 'beaker/testmode_switcher/version'
 Gem::Specification.new do |spec|
   spec.name          = "beaker-testmode_switcher"
   spec.version       = Beaker::TestmodeSwitcher::VERSION
-  spec.authors       = ["Puppet Labs", "David Schmitt", "Gareth Rushgrove", "Greg Hardy"]
+  spec.authors       = ["Puppet Labs", "David Schmitt", "Gareth Rushgrove", "Greg Hardy", "Paula McMaw"]
   spec.email         = ["modules-team@puppetlabs.com"]
 
   spec.summary       = "Let's you run your puppet module tests in master/agent, apply or local mode."

--- a/lib/beaker/testmode_switcher/version.rb
+++ b/lib/beaker/testmode_switcher/version.rb
@@ -1,6 +1,6 @@
 module Beaker
   # central definition of this gem's version
   module TestmodeSwitcher
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.1".freeze
   end
 end


### PR DESCRIPTION
Prepping to release to Rubygems with the new functionality that allows control on specific nodes to trigger a puppet agent. This makes it easier to run multi-node system type tests.