### PR TITLE
Release prep rubygems v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# Version 0.1.0
+# 2017-03-03 Version 0.2.0
+### Summary
+Make use of catch_changes, catch_failures, expect_changes and expect_failures. This makes beaker-testmode_switcher easier to integrate into modules.
 
-Initial release.
+### Features
+- Implement catch_changes, catch_failures, expect_changes and expect_failures in beaker_runners
+- Fix docs issue where `execute_manifest` options were listed under `resource
 
 # 2017-01-19 - Version 0.1.1
 ###Summary
@@ -11,3 +15,7 @@ This release adds a feature that provides control of specific nodes you would li
 - Add execute_manifest_on() function
 - Add MAINTAINERS file
 - Addressing Rubocop errors
+
+# Version 0.1.0
+
+Initial release.

--- a/lib/beaker/testmode_switcher/version.rb
+++ b/lib/beaker/testmode_switcher/version.rb
@@ -1,6 +1,6 @@
 module Beaker
   # central definition of this gem's version
   module TestmodeSwitcher
-    VERSION = "0.1.1".freeze
+    VERSION = "0.2.0".freeze
   end
 end


### PR DESCRIPTION
Prepping to release to Rubygems with the new functionality that allows extra functionality to allows the user to make use of catch_changes, catch_failures, expect_changes and expect_failures. This makes beaker-testmode_switcher easier to integrate into modules.