### PR TITLE
(QA-3002)(QA-3003) Fix local_runner errors on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 # increase the default metric limits to more realistic levels
 Metrics/BlockLength:
   Max: 200
@@ -28,7 +30,7 @@ Style/PercentLiteralDelimiters:
 Style/StringLiterals:
   Enabled: false
 
-Style/MultilineMethodCallBraceLayout:
+Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
 Style/FrozenStringLiteralComment:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3' unless ENV['TEST_FRAMEWORK'] && ENV['TEST_FRAMEWORK'] == 'beaker' # Don't install rpsec if the module is in beaker only mode
   gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :development do

--- a/Guardfile
+++ b/Guardfile
@@ -2,8 +2,7 @@
 # More info at https://github.com/guard/guard#readme
 
 ## Uncomment and set this to only include directories you want to watch
-directories %w(lib spec) \
-  .select { |d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist") }
+directories(%w(lib spec).select { |d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist") })
 
 ## Note: if you are using the `directories` clause above and you are not
 ## watching the project directory ('.'), then you will want to move

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ def beaker_command
   cmd_parts = []
   cmd_parts << "beaker"
   cmd_parts << "--debug"
-  cmd_parts << "--test spec/test"
+  cmd_parts << "--tests spec/test"
   cmd_parts << "--load-path lib"
   cmd_parts.flatten.join(" ")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 begin
-  task default: [:spec, :rubocop]
+  task default: %i[spec rubocop]
 rescue LoadError => error
   raise "LoadError for default rake target. [#{error}] "
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,10 @@ task :beaker do
   abort "Beaker test failed" unless system(beaker_command) == true
 end
 
-task :rubocop do
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  # These make the rubocop experience maybe slightly less terrible
+  task.options = ['-D', '-S', '-E']
 end
 
 begin

--- a/beaker-testmode_switcher.gemspec
+++ b/beaker-testmode_switcher.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'beaker/testmode_switcher/version'

--- a/lib/beaker/testmode_switcher/dsl.rb
+++ b/lib/beaker/testmode_switcher/dsl.rb
@@ -5,7 +5,7 @@ module Beaker
     # include this module into your namespace to access the DSL parts of TestmodeSwitcher
     module DSL
       # pass through methods to the runner
-      [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest, :execute_manifest_on].each do |name|
+      %i[create_remote_file_ex scp_to_ex shell_ex resource execute_manifest execute_manifest_on].each do |name|
         define_method(name) do |*args|
           Beaker::TestmodeSwitcher.runner(hosts, logger).send(name, *args)
         end

--- a/lib/beaker/testmode_switcher/local_runner.rb
+++ b/lib/beaker/testmode_switcher/local_runner.rb
@@ -148,8 +148,9 @@ module Beaker
                     retry
                   end
                 end
-              rescue EOFError # rubocop:disable Lint/HandleExceptions: expected exception
+              rescue EOFError, Errno::EBADF # rubocop:disable Lint/HandleExceptions: expected exception
                 # pass on EOF
+                # Also pass on Errno::EBADF (Bad File Descriptor) as it is thrown for Ruby 2.1.9 on Windows
               end
             end
           end

--- a/spec/beaker/testmode_switcher/runner_base_spec.rb
+++ b/spec/beaker/testmode_switcher/runner_base_spec.rb
@@ -41,7 +41,7 @@ describe Beaker::TestmodeSwitcher::RunnerBase do
     end
 
     it 'not throw UnacceptableExitCodeError when acceptable exit code given' do
-      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 2) }.to_not raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError)
+      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 2) }.not_to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError)
     end
   end
 end

--- a/spec/support/examples/a_runner.rb
+++ b/spec/support/examples/a_runner.rb
@@ -1,5 +1,5 @@
 shared_examples 'a runner' do
-  [:create_remote_file_ex, :scp_to_ex, :shell_ex, :resource, :execute_manifest, :execute_manifest_on].each do |name|
+  %i[create_remote_file_ex scp_to_ex shell_ex resource execute_manifest execute_manifest_on].each do |name|
     it { is_expected.to respond_to(name) }
   end
 end


### PR DESCRIPTION
While adding beaker-testmode_switcher tests to appveyor, we found errors running on Windows for Ruby 2.3 and Ruby 2.1

This PR contains 2 commits to address both failures.