### PR TITLE
(maint) Implement execute_manifest_on for apply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 2.3.1
   - 2.1.6
 env:
-  - TEST_FRAMEWORK="beaker-rspec"
+  - TEST_FRAMEWORK="rspec"
   - TEST_FRAMEWORK="beaker"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This experimental version supports only a minimal set of functionality from the 
 
 * `create_remote_file_ex(file_path, file_content, opts = {})`: Creates a file at `file_path` with the content specified in `file_content` on the default node. `opts` can have the keys `:mode`, `:user`, and `:group` to specify the permissions, owner, and group respectively.
 
-* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. This will only work when `BEAKER_TESTMODE`, is set to `agent` and it will run a `puppet agent` run.
-  
+* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. This will only work when `BEAKER_TESTMODE` is set to `agent` or `apply`, and is not yet supported for `local`.
+
   `opts` keys:
   * `:debug`, `:trace`, `:noop`: set to true to enable the puppet option of the same name.
   * `:dry_run`: set to true to skip executing the actual command.
@@ -56,7 +56,7 @@ This experimental version supports only a minimal set of functionality from the 
   * `:expect_failures` enables detailed exit codes and causes a test failure if the puppet run indicates there were no failure during its execution.
 
 * `execute_manifest(manifest, opts = {})`: Execute the manifest on the default node. Depending on the `BEAKER_TESTMODE` environment variable, this may use `puppet agent` or `puppet apply`. Calls execute_manifest_on when `BEAKER_TESTMODE`=`agent`
-  
+
   `opts` keys:
   * `:debug`, `:trace`, `:noop`: set to true to enable the puppet option of the same name.
   * `:dry_run`: set to true to skip executing the actual command.
@@ -91,7 +91,7 @@ Other helpful methods:
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Releasing
 

--- a/lib/beaker/testmode_switcher/beaker_runners.rb
+++ b/lib/beaker/testmode_switcher/beaker_runners.rb
@@ -105,9 +105,16 @@ module Beaker
     class BeakerApplyRunner < BeakerRunnerBase
       # execute the manifest by running puppet apply on the default node
       def execute_manifest(manifest, opts = {})
+        execute_manifest_on(default, manifest, opts)
+      end
+
+      # execute the manifest by running puppet apply on all the hosts
+      def execute_manifest_on(hosts, manifest, opts = {})
         # acceptable_exit_codes and expect_changes are passed because we want detailed-exit-codes but want to
         # make our own assertions about the responses
-        res = apply_manifest(
+
+        res = apply_manifest_on(
+          hosts,
           manifest,
           debug: opts[:debug],
           dry_run: opts[:dry_run],

--- a/spec/beaker/testmode_switcher/beaker_agent_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/beaker_agent_runner_spec.rb
@@ -7,4 +7,6 @@ describe Beaker::TestmodeSwitcher::BeakerAgentRunner do
   let(:subject) { described_class.new :hosts, :logger }
 
   it_behaves_like "a runner"
+  # when run in isolation, the DSL module may not be mixed in
+  it_behaves_like "a fully implemented runner" if defined?(Beaker::TestmodeSwitcher::DSL)
 end

--- a/spec/beaker/testmode_switcher/beaker_apply_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/beaker_apply_runner_spec.rb
@@ -7,4 +7,6 @@ describe Beaker::TestmodeSwitcher::BeakerApplyRunner do
   let(:subject) { described_class.new :hosts, :logger }
 
   it_behaves_like "a runner"
+  # when run in isolation, the DSL module may not be mixed in
+  it_behaves_like "a fully implemented runner" if defined?(Beaker::TestmodeSwitcher::DSL)
 end

--- a/spec/beaker/testmode_switcher/dsl_spec.rb
+++ b/spec/beaker/testmode_switcher/dsl_spec.rb
@@ -47,5 +47,6 @@ describe Beaker::TestmodeSwitcher::DSL do
 
   describe '#runner' do
     it_behaves_like "a runner"
+    it_behaves_like "a fully implemented runner"
   end
 end

--- a/spec/support/examples/a_runner.rb
+++ b/spec/support/examples/a_runner.rb
@@ -1,5 +1,16 @@
+methods = %i[create_remote_file_ex scp_to_ex shell_ex resource execute_manifest execute_manifest_on]
+
 shared_examples 'a runner' do
-  %i[create_remote_file_ex scp_to_ex shell_ex resource execute_manifest execute_manifest_on].each do |name|
+  methods.each do |name|
     it { is_expected.to respond_to(name) }
+  end
+end
+
+shared_examples 'a fully implemented runner' do
+  methods.each do |name|
+    it "should implement #{name} instead of mixing in Beaker::TestmodeSwitcher::DSL" do
+      method = subject.class.instance_method(name)
+      expect(method.owner).to_not be(Beaker::TestmodeSwitcher::DSL)
+    end
   end
 end


### PR DESCRIPTION
 - For the execute_manifest_on helper to be useful for both masterless
   and master / agent scenarios, the BeakerApplyRunner must also implement
   `execute_manifest_on`

   As it is currently only implemented against BeakerAgentRunner, that
   prevents tests from using `execute_manifest_on`, defeating the
   purpose of having this method.

 - Test suites do execute in masterless mode with multiple agents,
   where `execute_manifest_on` is quite useful to run on only a set
   of hosts. This method is also particularly useful when Windows
   specific tests are run in a master / agent scenario and the list of
   hosts is filtered to remove non-Windows nodes.