### PR TITLE
(maint) Add execute_manifest_on for local runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This experimental version supports only a minimal set of functionality from the 
 
 * `create_remote_file_ex(file_path, file_content, opts = {})`: Creates a file at `file_path` with the content specified in `file_content` on the default node. `opts` can have the keys `:mode`, `:owner`, and `:group` to specify the permissions, owner, and group respectively.
 
-* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. This will only work when `BEAKER_TESTMODE` is set to `agent` or `apply`, and is not yet supported for `local`.
+* `execute_manifest_on(hosts, manifest, opts = {})`: Execute the manifest on all nodes. This is supported for all variants of `BEAKER_TESTMODE`, but the `hosts` parameter is ignored when set to `local`.
 
   `opts` keys:
   * `:debug`, `:trace`, `:noop`: set to true to enable the puppet option of the same name.

--- a/lib/beaker/testmode_switcher/local_runner.rb
+++ b/lib/beaker/testmode_switcher/local_runner.rb
@@ -26,6 +26,14 @@ module Beaker
       # executes the supplied manifest using bundle and puppet apply
       # the opts hash works like the opts of [apply_manifest_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#apply_manifest_on-instance_method) in the Beaker DSL.
       # it accepts the following keys: :dry_run, :environment, :trace, :noop, and :debug
+      def execute_manifest_on(hosts, manifest, opts = {})
+        warn "hosts parameter is ignored for the local runner"
+        execute_manifest(manifest, opts)
+      end
+
+      # executes the supplied manifest using bundle and puppet apply
+      # the opts hash works like the opts of [apply_manifest_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#apply_manifest_on-instance_method) in the Beaker DSL.
+      # it accepts the following keys: :dry_run, :environment, :trace, :noop, and :debug
       def execute_manifest(manifest, opts = {})
         puts "Applied manifest [#{manifest}]" if ENV['DEBUG_MANIFEST']
         cmd = ["bundle exec puppet apply -e #{manifest.shellescape} --detailed-exitcodes --modulepath spec/fixtures/modules --libdir lib"]

--- a/spec/beaker/testmode_switcher/local_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/local_runner_spec.rb
@@ -5,6 +5,8 @@ describe Beaker::TestmodeSwitcher::LocalRunner do
   let(:subject) { described_class.new }
 
   it_behaves_like "a runner"
+  # when run in isolation, the DSL module may not be mixed in
+  it_behaves_like "a fully implemented runner" if defined?(Beaker::TestmodeSwitcher::DSL)
 
   describe '#create_remote_file_ex' do
     before :each do


### PR DESCRIPTION
For API parity this should probably be added as well.

(maint) Add execute_manifest_on for local runner  …
 - Support full API parity, even for a local runner where it doesn't
   make a lot of sense.

   Without this support it makes it difficult to work on test suites
   that require the use of execute_manifest_on.

   Emit a warning that the "hosts" parameter is ignored given there
   is only one host and it doesn't make sense.