### PR TITLE
(maint) Ensure handle_puppet_run_returned_exit_code can use a Range 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,7 @@ Bundler/DuplicatedGem:
 # When there are dependencies we have duplicate gems so they cant be ordered
 Bundler/OrderedGems:
   Enabled: false
+
+# Useless detection on Windows
+Layout/EndOfLine:
+  Enabled: false

--- a/beaker-testmode_switcher.gemspec
+++ b/beaker-testmode_switcher.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'beaker/testmode_switcher/version'
 

--- a/lib/beaker/testmode_switcher/dsl.rb
+++ b/lib/beaker/testmode_switcher/dsl.rb
@@ -17,4 +17,4 @@ module Beaker
   end
 end
 
-include Beaker::TestmodeSwitcher::DSL
+include Beaker::TestmodeSwitcher::DSL # rubocop:disable Style/MixinUsage  This usage is expected

--- a/lib/beaker/testmode_switcher/runner_base.rb
+++ b/lib/beaker/testmode_switcher/runner_base.rb
@@ -23,12 +23,17 @@ module Beaker
 
         # If no option supplied, return all exit codes, as an array,
         # as acceptable so beaker returns a detailed output
-        (0...256)
+        0...256
       end
 
       def handle_puppet_run_returned_exit_code(acceptable_exit_codes, returned_exit_code)
         return if acceptable_exit_codes.include?(returned_exit_code)
-        raise UnacceptableExitCodeError, "Unacceptable exit code returned: #{returned_exit_code}. Acceptable code(s): #{acceptable_exit_codes.join(', ')}"
+        acceptable_exit_codes_string = if acceptable_exit_codes.is_a?(Array)
+                                         acceptable_exit_codes.join(', ')
+                                       else
+                                         acceptable_exit_codes_string.to_s
+                                       end
+        raise UnacceptableExitCodeError, "Unacceptable exit code returned: #{returned_exit_code}. Acceptable code(s): #{acceptable_exit_codes_string}"
       end
     end
   end

--- a/spec/beaker/testmode_switcher/local_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/local_runner_spec.rb
@@ -29,9 +29,9 @@ describe Beaker::TestmodeSwitcher::LocalRunner do
       expect(File.read(@target)).to eq "content\n"
     end
 
-    it 'creates a file with mode', :unless => windows_platform? do
+    it 'creates a file with mode', unless: windows_platform? do
       subject.create_remote_file_ex(@target, "content\n", mode: '0700')
-      mode = format("%o", File.stat(@target).mode)
+      mode = format("%o", File.stat(@target).mode) # rubocop:disable Style/FormatStringToken  Safe conversion in this instance
       expect(mode).to eq "100700"
     end
   end

--- a/spec/beaker/testmode_switcher/local_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/local_runner_spec.rb
@@ -29,7 +29,7 @@ describe Beaker::TestmodeSwitcher::LocalRunner do
       expect(File.read(@target)).to eq "content\n"
     end
 
-    it 'creates a file with mode' do
+    it 'creates a file with mode', :unless => windows_platform? do
       subject.create_remote_file_ex(@target, "content\n", mode: '0700')
       mode = format("%o", File.stat(@target).mode)
       expect(mode).to eq "100700"

--- a/spec/beaker/testmode_switcher/runner_base_spec.rb
+++ b/spec/beaker/testmode_switcher/runner_base_spec.rb
@@ -3,39 +3,39 @@ require 'spec_helper'
 describe Beaker::TestmodeSwitcher::RunnerBase do
   subject { Beaker::TestmodeSwitcher::RunnerBase.new }
 
-  context 'get_acceptable_puppet_run_exit_codes' do
-    context ':catch_changes option passed' do
+  describe 'get_acceptable_puppet_run_exit_codes' do
+    context 'when :catch_changes option passed' do
       it 'exit code of 0 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(catch_changes: true)).to eq([0])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit codes of 0 & 2 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(catch_failures: true)).to eq([0, 2])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit codes 1, 4 & 6 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(expect_failures: true)).to eq([1, 4, 6])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit code of 2 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(expect_changes: true)).to eq([2])
       end
     end
 
-    context 'no options passed' do
+    context 'when no options passed' do
       it 'exit codes 0 - 256 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes).to eq((0...256))
       end
     end
   end
 
-  context 'handle_puppet_run_returned_exit_code' do
+  describe 'handle_puppet_run_returned_exit_code' do
     it 'throws UnacceptableExitCodeError when unacceptable exit code given' do
       expect { subject.handle_puppet_run_returned_exit_code([0, 2], 5) }.to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError, /Unacceptable exit code returned/i)
     end

--- a/spec/beaker/testmode_switcher/runner_base_spec.rb
+++ b/spec/beaker/testmode_switcher/runner_base_spec.rb
@@ -40,8 +40,16 @@ describe Beaker::TestmodeSwitcher::RunnerBase do
       expect { subject.handle_puppet_run_returned_exit_code([0, 2], 5) }.to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError, /Unacceptable exit code returned/i)
     end
 
-    it 'not throw UnacceptableExitCodeError when acceptable exit code given' do
-      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 2) }.not_to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError)
+    it 'throws UnacceptableExitCodeError when unacceptable exit code given for a range' do
+      expect { subject.handle_puppet_run_returned_exit_code((0..2), 5) }.to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError, /Unacceptable exit code returned/i)
+    end
+
+    it 'not throw when acceptable exit code given' do
+      expect { subject.handle_puppet_run_returned_exit_code([0, 2], 2) }.not_to raise_error
+    end
+
+    it 'not throw when acceptable exit code given for a range' do
+      expect { subject.handle_puppet_run_returned_exit_code((0..10), 2) }.not_to raise_error
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,9 @@ require 'beaker/testmode_switcher'
 
 # automatically load any shared examples or contexts
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
+def windows_platform?
+  # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+  # requiring features to be initialized and without side effect.
+  !!File::ALT_SEPARATOR
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,5 +6,5 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 def windows_platform?
   # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
   # requiring features to be initialized and without side effect.
-  !!File::ALT_SEPARATOR
+  !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation  Completely expected in this instance
 end

--- a/spec/support/examples/a_runner.rb
+++ b/spec/support/examples/a_runner.rb
@@ -10,7 +10,7 @@ shared_examples 'a fully implemented runner' do
   methods.each do |name|
     it "should implement #{name} instead of mixing in Beaker::TestmodeSwitcher::DSL" do
       method = subject.class.instance_method(name)
-      expect(method.owner).to_not be(Beaker::TestmodeSwitcher::DSL)
+      expect(method.owner).not_to be(Beaker::TestmodeSwitcher::DSL)
     end
   end
 end


### PR DESCRIPTION
Previously if none of the catch_* and expect_* options where set the
get_acceptable_puppet_run_exit_codes method would emit a Range (0..256).  However
this raised errors in the handle_puppet_run_returned_exit_code method because
you cannot do a `.join` on a Range.  This commit changes the output if it as an
array;  Joining if it is an array and converting to a string for other types.

Tests have been added for this behavior.