### PR TITLE
(QA-3461) - Making `execute_manifest_on` compatible with `handle_puppet_run_returned_exit_code`

### DIFF
--- a/beaker-testmode_switcher.gemspec
+++ b/beaker-testmode_switcher.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'beaker/testmode_switcher/version'
 

--- a/lib/beaker/testmode_switcher/beaker_runners.rb
+++ b/lib/beaker/testmode_switcher/beaker_runners.rb
@@ -96,7 +96,13 @@ module Beaker
                  environment: opts[:environment] || {},
                  acceptable_exit_codes: (0...256))
 
-        handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), res.exit_code)
+        if res.is_a? Array
+          res.each do |result|
+            handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), result.exit_code)
+          end
+        else
+          handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), res.exit_code)
+        end
         res
       end
     end
@@ -124,7 +130,13 @@ module Beaker
           expect_failures: true,
           acceptable_exit_codes: (0...256))
 
-        handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), res.exit_code)
+        if res.is_a? Array
+          res.each do |result|
+            handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), result.exit_code)
+          end
+        else
+          handle_puppet_run_returned_exit_code(get_acceptable_puppet_run_exit_codes(opts), res.exit_code)
+        end
         res
       end
     end

--- a/lib/beaker/testmode_switcher/dsl.rb
+++ b/lib/beaker/testmode_switcher/dsl.rb
@@ -17,4 +17,4 @@ module Beaker
   end
 end
 
-include Beaker::TestmodeSwitcher::DSL
+include Beaker::TestmodeSwitcher::DSL # rubocop:disable Style/MixinUsage  This usage is expected

--- a/spec/beaker/testmode_switcher/dsl_spec.rb
+++ b/spec/beaker/testmode_switcher/dsl_spec.rb
@@ -13,24 +13,28 @@ describe Beaker::TestmodeSwitcher::DSL do
       create_remote_file_ex('/tmp/foo', 'content', {})
     end
   end
+
   describe '#scp_to_ex' do
     it 'is callable' do
       is_expected.to receive(:scp_to_ex)
       scp_to_ex('/tmp/from', '/tmp/to')
     end
   end
+
   describe '#shell_ex' do
     it 'is callable' do
       is_expected.to receive(:shell_ex)
       shell_ex('cmd', {})
     end
   end
+
   describe '#resource' do
     it 'is callable' do
       is_expected.to receive(:resource)
       resource('type', 'name', {})
     end
   end
+
   describe '#execute_manifest' do
     it 'is callable' do
       is_expected.to receive(:execute_manifest)

--- a/spec/beaker/testmode_switcher/local_runner_spec.rb
+++ b/spec/beaker/testmode_switcher/local_runner_spec.rb
@@ -31,7 +31,7 @@ describe Beaker::TestmodeSwitcher::LocalRunner do
 
     it 'creates a file with mode' do
       subject.create_remote_file_ex(@target, "content\n", mode: '0700')
-      mode = format("%o", File.stat(@target).mode)
+      mode = format("%o", File.stat(@target).mode) # rubocop:disable Style/FormatStringToken  Safe conversion in this instance
       expect(mode).to eq "100700"
     end
   end

--- a/spec/beaker/testmode_switcher/runner_base_spec.rb
+++ b/spec/beaker/testmode_switcher/runner_base_spec.rb
@@ -3,39 +3,39 @@ require 'spec_helper'
 describe Beaker::TestmodeSwitcher::RunnerBase do
   subject { Beaker::TestmodeSwitcher::RunnerBase.new }
 
-  context 'get_acceptable_puppet_run_exit_codes' do
-    context ':catch_changes option passed' do
+  context 'when get_acceptable_puppet_run_exit_codes' do
+    context 'when :catch_changes option passed' do
       it 'exit code of 0 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(catch_changes: true)).to eq([0])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit codes of 0 & 2 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(catch_failures: true)).to eq([0, 2])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit codes 1, 4 & 6 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(expect_failures: true)).to eq([1, 4, 6])
       end
     end
 
-    context ':catch_changes option passed' do
+    context 'when :catch_changes option passed' do
       it 'exit code of 2 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes(expect_changes: true)).to eq([2])
       end
     end
 
-    context 'no options passed' do
+    context 'when no options passed' do
       it 'exit codes 0 - 256 given' do
         expect(subject.get_acceptable_puppet_run_exit_codes).to eq((0...256))
       end
     end
   end
 
-  context 'handle_puppet_run_returned_exit_code' do
+  context 'when handle_puppet_run_returned_exit_code' do
     it 'throws UnacceptableExitCodeError when unacceptable exit code given' do
       expect { subject.handle_puppet_run_returned_exit_code([0, 2], 5) }.to raise_error(Beaker::TestmodeSwitcher::UnacceptableExitCodeError, /Unacceptable exit code returned/i)
     end

--- a/spec/support/examples/a_runner.rb
+++ b/spec/support/examples/a_runner.rb
@@ -10,7 +10,7 @@ shared_examples 'a fully implemented runner' do
   methods.each do |name|
     it "should implement #{name} instead of mixing in Beaker::TestmodeSwitcher::DSL" do
       method = subject.class.instance_method(name)
-      expect(method.owner).to_not be(Beaker::TestmodeSwitcher::DSL)
+      expect(method.owner).not_to be(Beaker::TestmodeSwitcher::DSL)
     end
   end
 end


### PR DESCRIPTION
Currently when applying to multiple hosts using `execute_manifest_on` the exit code is returned in an array. This results in `handle_puppet_run_returned_exit_code` throwing an exception as the returned exit code is set to `nil`. 

The implementation means that it is able to run on more than one host. 

I have tested that this doesn't break existing functionality by testing MySQL module that I am currently implementing TMS on https://github.com/puppetlabs/puppetlabs-mysql/pull/1095:

Master-agent AIO setup (1 node): BEAKER_TESTMODE=agent PUPPET_INSTALL_TYPE=pe
Agent Only setup (1 node): BEAKER_TESTMODE=apply PUPPET_INSTALL_TYPE=agent
Master Agent Setup (2 nodes): BEAKER_TESTMODE=agent PUPPET_INSTALL_TYPE=pe

This PR has also ran internally on our adhoc pipelines for mysql with no failures.