### PR TITLE
(MODULES-7478) - Release Prep for 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2018-17-07 Version 0.4.1
+#### Summary
+This release corrects a bug that doesn't return results correctly when multiple hosts are specified.
+
+### BugFixes
+- execute_manifest_on doesn't return results correctly when multiple hosts are specified.
+
 # 2018-03-07 Version 0.4.0
 ### Summary
 Adds the ability for execute_manifest_on to work in both agent and apply; improvements for create_remote_file_ex.

--- a/lib/beaker/testmode_switcher/version.rb
+++ b/lib/beaker/testmode_switcher/version.rb
@@ -1,6 +1,6 @@
 module Beaker
   # central definition of this gem's version
   module TestmodeSwitcher
-    VERSION = "0.4.0".freeze
+    VERSION = "0.4.1".freeze
   end
 end


### PR DESCRIPTION
This is a minor release that contains a bug fix. 
Releasing as I need it to continue with another ticket to implement beaker-testmode_switcher into a supported module. 